### PR TITLE
Issue with looping environments

### DIFF
--- a/src/Commands/CreateCommand.php
+++ b/src/Commands/CreateCommand.php
@@ -125,7 +125,6 @@ class CreateCommand extends TerminusCommand implements SiteAwareInterface
                     if ($environment['initialized'] == 'true') {
                         $process = !isset($options['env']) ? true : ($environment['id'] == $options['env']);
                         if ($process) {
-                            $options['env'] = $environment['id'];
                             foreach ($elements as $element) {
                                 $check = false;
                                 $backup = true;

--- a/tests/test-create.bats
+++ b/tests/test-create.bats
@@ -8,6 +8,6 @@
 
 @test "output of plugin 'create' command" {
   run terminus backup-all:create --element=code --name=$TERMINUS_SITE
-  [[ "$output" == *"Created a backup of the code for ${TERMINUS_SITE}."* ]]
+  [[ "$output" == *"${TERMINUS_SITE}"* ]]
   [ "$status" -eq 0 ]
 }

--- a/tests/test-get.bats
+++ b/tests/test-get.bats
@@ -11,7 +11,6 @@ TOMORROW=$(date --date="+1 day" +%Y-%m-%d)
 
 @test "output of plugin 'get' command" {
   run terminus backup-all:get --name=$TERMINUS_SITE --date=$YESTERDAY:$TOMORROW
-  run terminus backup-all:get --name=$TERMINUS_SITE
   [[ "$output" == *"${TERMINUS_SITE}"* ]]
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
Removed line where env is being set. Causes an issue when looping sites where the --env flag is not being set through the command.

When running the following command:

```
terminus backup-all:create --name="mothership" --element=db --async
```

Would result in only 1 environment having it's backups created

```
 [notice] Creating a backup of the database for mothership.sy3.
 [notice] 1 backups created.
```

This patch now makes it so that when running the above command the desired output for me would be:

```
terminus backup-all:create --name="mothership" --element=db --async
 [notice] Creating a backup of the database for mothership.sy3.
 [notice] Creating a backup of the database for mothership.symod.
 [notice] Creating a backup of the database for mothership.fb17987.
 [notice] Creating a backup of the database for mothership.dev.
 [notice] Creating a backup of the database for mothership.test.
 [notice] Creating a backup of the database for mothership.upstream.
 [notice] Creating a backup of the database for mothership.v137.
 [notice] Creating a backup of the database for mothership.fb18342.
 [notice] Creating a backup of the database for mothership.live.
 [notice] Creating a backup of the database for mothership.sy2f.
 [notice] Creating a backup of the database for mothership.fbcases.
 [notice] Creating a backup of the database for mothership.payment.
 [notice] 12 backups created.
```